### PR TITLE
chore: :pencil2: use jzmq.ZMQ.PollerEvent instead of int32

### DIFF
--- a/+jzmq/+ZMQ/Poller.m
+++ b/+jzmq/+ZMQ/Poller.m
@@ -31,7 +31,7 @@ classdef Poller < handle
             arguments
                 obj
                 socket (1, 1) jzmq.ZMQ.Socket
-                event (1, 1) int32 = 1
+                event (1, 1) jzmq.ZMQ.PollerEvent = jzmq.ZMQ.PollerEvent.POLLIN
 			end
 
 			obj.socket = socket;


### PR DESCRIPTION
Please check this issue: https://github.com/CogPlatform/matlab-jzmq/issues/6